### PR TITLE
Tighten init, elide invalid detectives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ builtin-clean:
 
 builtin-prep:
 	@docker build -t v2c/guestfish-export:1 -f ./packager/guestfish-export.df ./packager/
+	@docker build -t v2c/tar-importer:1 -f ./packager/tar-importer.df ./packager/
 
 	@docker build -t v2c/centos-detective:v6.8   -f ./detectives/os.centos6.8.df ./detectives/
 	@docker build -t v2c/centos-provisioner:v6.8 -f ./provisioners/os.centos6.8.df ./provisioners/

--- a/api/interface.go
+++ b/api/interface.go
@@ -23,6 +23,7 @@ type Packager struct {
 	Tag         string
 	Category    string
 	Description string
+	Supports    string
 }
 
 type Product struct {

--- a/packager/guestfish-export.df
+++ b/packager/guestfish-export.df
@@ -2,7 +2,8 @@ FROM curator/guestfish
 LABEL com.docker.v2c.component=packager \
       com.docker.v2c.component.category=export \
       com.docker.v2c.component.builtin=1 \
-      com.docker.v2c.component.description=Copies\ disk\ contents\ into\ /v2c/disk
+      com.docker.v2c.component.description=Copies\ disk\ contents\ into\ /v2c/disk \
+      com.docker.v2c.component.supports=default,vmdk,raw
 COPY ./guestfish-export/script.sh /script.sh
 VOLUME ["/v2c"]
 ENTRYPOINT ["/bin/sh"]

--- a/packager/tar-importer.df
+++ b/packager/tar-importer.df
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+LABEL com.docker.v2c.component=packager \
+      com.docker.v2c.component.category=export \
+      com.docker.v2c.component.builtin=1 \
+      com.docker.v2c.component.description=Copies\ tarball\ contents\ into\ /v2c/disk \
+      com.docker.v2c.component.supports=tar
+COPY tar-importer/run.sh /
+CMD ["/run.sh"]

--- a/packager/tar-importer/run.sh
+++ b/packager/tar-importer/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+mkdir /v2c/disk
+cd /v2c/disk
+tar xf /input/input

--- a/system/docker.go
+++ b/system/docker.go
@@ -28,6 +28,7 @@ var (
 		`component`:   `com.docker.v2c.component`,
 		`category`:    `com.docker.v2c.component.category`,
 		`description`: `com.docker.v2c.component.description`,
+		`supports`:    `com.docker.v2c.component.supports`,
 		`related`:     `com.docker.v2c.component.rel`,
 	}
 )
@@ -479,6 +480,7 @@ func packagersFromImageSummary(i types.ImageSummary) []api.Packager {
 				Tag:         p[1],
 				Category:    i.Labels[labels[`category`]],
 				Description: i.Labels[labels[`description`]],
+				Supports:    i.Labels[labels[`supports`]],
 			})
 		}
 	} else {


### PR DESCRIPTION
currently if a detectives runs and doesn't point to a correct provisioner, things break
    
this prevents those detective from ever running by first verifying during the init phase that the
